### PR TITLE
More robust constraint setting

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -32,7 +32,7 @@ def dicts_product(**kwargs):
         yield dict(zip(keys, instance))
 
 
-class TestHomogeneous(TestCase):
+class TestIntegration(TestCase):
     def sizes(self, square):
         sizes = []
         if not torch.cuda.is_available():


### PR DESCRIPTION
Fixes: #8
Layer is now created in the same device and with the same dtype as the tensor it is put on:
```python
import torch
import geotorch
from torch import nn
n = 10
Q = nn.Linear(n, n, bias=False).double().cuda()
geotorch.orthogonal(Q, "weight")  # The orthogonal layer is in double precision and GPU
Q(torch.ones(10).double())
```