### PR TITLE
Adding parameterizations of Hurwitz matrices

### DIFF
--- a/examples/eigenvalue.py
+++ b/examples/eigenvalue.py
@@ -3,6 +3,7 @@ In this program we show how to use GeoTorch to compute the maximum eigenvalue
 of a symmetric matrix via the Rayleigh quotient, restricting the optimisation
 problem to the Sphere
 """
+
 import torch
 
 try:

--- a/geotorch/__init__.py
+++ b/geotorch/__init__.py
@@ -13,7 +13,7 @@ from .constraints import (
     positive_semidefinite,
     positive_semidefinite_low_rank,
     positive_semidefinite_fixed_rank,
-    alpha_stable
+    alpha_stable,
 )
 from .product import ProductManifold
 from .reals import Rn

--- a/geotorch/__init__.py
+++ b/geotorch/__init__.py
@@ -13,6 +13,7 @@ from .constraints import (
     positive_semidefinite,
     positive_semidefinite_low_rank,
     positive_semidefinite_fixed_rank,
+    alpha_stable
 )
 from .product import ProductManifold
 from .reals import Rn
@@ -31,6 +32,7 @@ from .psd import PSD
 from .pssd import PSSD
 from .pssdfixedrank import PSSDFixedRank
 from .pssdlowrank import PSSDLowRank
+from .hurwitz import Hurwitz
 from .utils import update_base
 
 
@@ -56,6 +58,7 @@ __all__ = [
     "PSSD",
     "PSSDLowRank",
     "PSSDFixedRank",
+    "Hurwitz",
     "skew",
     "symmetric",
     "sphere",
@@ -70,5 +73,6 @@ __all__ = [
     "positive_semidefinite",
     "positive_semidefinite_low_rank",
     "positive_semidefinite_fixed_rank",
+    "alpha_stable",
     "update_base",
 ]

--- a/geotorch/constraints.py
+++ b/geotorch/constraints.py
@@ -553,10 +553,11 @@ def positive_semidefinite_fixed_rank(
 
 
 def alpha_stable(module: torch.nn.Module, tensor_name="weight", alpha=1e-3):
-    r"""Adds an alpha_stability parametrization to the matrix ``module.tensor_name``.
+    r"""Adds an :math:`alpha`-stability constraint to the matrix ``module.tensor_name``.
 
     When accessing ``module.tensor_name``, the module will return the parametrized
-    version :math:`A` so that :math:`\min_{\lambda \in Sp(A)} \Re(\lambda)<= -\alpha`.
+    version :math:`X` so that all of its eigenvalues have a negative real part lower
+    than :math:`-\alpha`, with :math:`\alpha \geq 0`.
 
     If the tensor has more than two dimensions, the parametrization will be
     applied to the last two dimensions.
@@ -565,13 +566,13 @@ def alpha_stable(module: torch.nn.Module, tensor_name="weight", alpha=1e-3):
 
         >>> layer = nn.Linear(30, 30)
         >>> alpha_stable(layer, "weight", alpha=2)
-        >>> torch.all(torch.linalg.eigvals(layer.weight)<=-layer.alpha)
+        >>> torch.all(torch.real(torch.linalg.eigvals(layer.weight))<=-layer.alpha)
         True
 
     Args:
         module (nn.Module): module on which to register the parametrization
         tensor_name (string): name of the parameter, buffer, or parametrization
             on which the parametrization will be applied. Default: ``"weight"``
-        alpha (float): Bound on the decay rate and eigevenalues of matrix A
+        alpha (float): Absolute value of the upper bound on the real part of the eigevenalues of :math: `X`
     """
     return _register_manifold(module, tensor_name, Hurwitz, alpha)

--- a/geotorch/constraints.py
+++ b/geotorch/constraints.py
@@ -85,7 +85,7 @@ def skew(module, tensor_name="weight", lower=True):
         lower (bool): Optional. Uses the lower triangular part of the matrix to
             parametrize the matrix. Default: ``True``
     """
-    return  _register_manifold(module, tensor_name, Skew, lower)
+    return _register_manifold(module, tensor_name, Skew, lower)
 
 
 def sphere(module, tensor_name="weight", radius=1.0, embedded=False):

--- a/geotorch/constraints.py
+++ b/geotorch/constraints.py
@@ -552,11 +552,11 @@ def positive_semidefinite_fixed_rank(
     return _register_manifold(module, tensor_name, PSSDFixedRank, rank, f, triv)
 
 
-def alpha_stable(module, tensor_name="weight", alpha=0.0):
+def alpha_stable(module: torch.nn.Module, tensor_name="weight", alpha=1e-3):
     r"""Adds an alpha_stability parametrization to the matrix ``module.tensor_name``.
 
     When accessing ``module.tensor_name``, the module will return the parametrized
-    version :math:`X` so that :math:`X^\intercal = -X`.
+    version :math:`A` so that :math:`\min_{\lambda \in Sp(A)} \Re(\lambda)<= -\alpha`.
 
     If the tensor has more than two dimensions, the parametrization will be
     applied to the last two dimensions.

--- a/geotorch/hurwitz.py
+++ b/geotorch/hurwitz.py
@@ -3,7 +3,6 @@ import math
 from .psd import PSD
 from .skew import Skew
 from .product import ProductManifold
-from .exceptions import VectorError, NonSquareError
 from .utils import _extra_repr
 from .exceptions import (
     VectorError,
@@ -46,7 +45,7 @@ class Hurwitz(ProductManifold):
         self.n = n
         self.tensorial_size = tensorial_size
         self.alpha = alpha
-        self.register_buffer('In', torch.eye(n).expand(*self.tensorial_size, n, n))
+        self.register_buffer("In", torch.eye(n).expand(*self.tensorial_size, n, n))
 
     @classmethod
     def parse_size(cls, size):
@@ -72,14 +71,14 @@ class Hurwitz(ProductManifold):
 
     def submersion_inv(self, A: torch.Tensor, check_in_manifold=True, rho=1, tol=1e-4):
         r"""
-            Args: 
-                A (torch.Tensor): a square and Hurwitz matrix with eigenvalues lower than -alpha
-                check_in_manifold (bool): if set to True we raise an error if the matrix A is not in
-                the manifold
+        Args:
+            A (torch.Tensor): a square and Hurwitz matrix with eigenvalues lower than -alpha
+            check_in_manifold (bool): if set to True we raise an error if the matrix A is not in
+            the manifold
 
-                rho (float): a scaling parameter for the matrix Q = -rho I
+            rho (float): a scaling parameter for the matrix Q = -rho I
 
-                tol (float): a small margin to ensure P is not close to singularity, can be increased if needed
+            tol (float): a small margin to ensure P is not close to singularity, can be increased if needed
 
         """
         if check_in_manifold and not self.in_manifold_eigen(A):
@@ -101,7 +100,7 @@ class Hurwitz(ProductManifold):
             M_flat = torch.vmap(_single_kron_sum)(A_flat)
             M = M_flat.reshape(*self.tensorial_size, self.n * self.n, self.n * self.n)
 
-            Q = (rho * self.In)
+            Q = rho * self.In
             flat_Q = Q.flatten(-2, -1)
 
             vec_P = torch.linalg.solve(M, -flat_Q.unsqueeze(-1)).squeeze(-1)
@@ -110,7 +109,8 @@ class Hurwitz(ProductManifold):
             residual = torch.norm(A.mT @ P + P @ A + 2 * (self.alpha - tol) * P + Q)
             if residual >= tol:
                 raise ValueError(
-                    f"Lyapunov equation ill-conditioned solve failed. \n Residual norm: {torch.norm(residual):.2e}")
+                    f"Lyapunov equation ill-conditioned solve failed. \n Residual norm: {torch.norm(residual):.2e}"
+                )
 
             S = P @ (A + (self.alpha - tol) * self.In) + 0.5 * Q
 
@@ -164,7 +164,4 @@ class Hurwitz(ProductManifold):
 
     def extra_repr(self) -> str:
         print(self.alpha)
-        return _extra_repr(
-            n=self.n,
-            alpha=self.alpha
-        )
+        return _extra_repr(n=self.n, alpha=self.alpha)

--- a/geotorch/hurwitz.py
+++ b/geotorch/hurwitz.py
@@ -46,6 +46,9 @@ class Hurwitz(ProductManifold):
         self.tensorial_size = tensorial_size
         self.alpha = alpha
         self.register_buffer("In", torch.eye(n).expand(*self.tensorial_size, n, n))
+        self.register_buffer(
+            "alphaIn", self.alpha * torch.eye(n).expand(*self.tensorial_size, n, n)
+        )
 
     @classmethod
     def parse_size(cls, size):
@@ -63,7 +66,7 @@ class Hurwitz(ProductManifold):
         return PSD(size, triv=triv), PSD(size, triv=triv), Skew(size)
 
     def submersion(self, Q, P, S):
-        return P @ (-0.5 * Q + S) - self.alpha * self.In
+        return P @ torch.add(S, Q, alpha=-0.5) - self.alphaIn
 
     def forward(self, X1, X2, X3):
         Q, P, S = super().forward([X1, X2, X3])

--- a/geotorch/hurwitz.py
+++ b/geotorch/hurwitz.py
@@ -1,4 +1,5 @@
 import torch
+import math
 from .psd import PSD
 from .skew import Skew
 from .product import ProductManifold
@@ -10,8 +11,10 @@ from .exceptions import (
     InManifoldError,
 )
 
+
 def get_lyap_exp(A):
     return -torch.max(torch.real(torch.linalg.eigvals(A)))
+
 
 class Hurwitz(ProductManifold):
 
@@ -36,7 +39,7 @@ class Hurwitz(ProductManifold):
                 callable. Default: ``"expm"``
         """
 
-        assert alpha >=0, ValueError(f"alpha must be positive found {alpha}")
+        assert alpha >= 0, ValueError(f"alpha must be positive found {alpha}")
 
         n, tensorial_size = Hurwitz.parse_size(size)
         super().__init__(Hurwitz.manifolds(n, tensorial_size, triv))
@@ -54,22 +57,20 @@ class Hurwitz(ProductManifold):
         if n != k:
             raise NonSquareError(cls.__name__, size)
         return n, tensorial_size
-    
+
     @staticmethod
     def manifolds(n, tensorial_size, triv):
-        size =  tensorial_size + (n, n)
+        size = tensorial_size + (n, n)
         return PSD(size, triv=triv), PSD(size, triv=triv), Skew(size)
-    
 
     def submersion(self, Q, P, S):
-            return P @ (-0.5 * Q + S) - self.alpha * self.In
+        return P @ (-0.5 * Q + S) - self.alpha * self.In
 
     def forward(self, X1, X2, X3):
         Q, P, S = super().forward([X1, X2, X3])
         return self.submersion(Q, P, S)
 
-
-    def submersion_inv(self, A: torch.Tensor, check_in_manifold=True, rho=1, tol = 1e-4):
+    def submersion_inv(self, A: torch.Tensor, check_in_manifold=True, rho=1, tol=1e-4):
         r"""
             Args: 
                 A (torch.Tensor): a square and Hurwitz matrix with eigenvalues lower than -alpha
@@ -84,45 +85,44 @@ class Hurwitz(ProductManifold):
         if check_in_manifold and not self.in_manifold_eigen(A):
             print(f"Enforced alpha = {self.alpha} and given alpha = {get_lyap_exp(A)}")
             raise InManifoldError(get_lyap_exp(A), self.alpha)
-        
+
         with torch.no_grad():
-            A_shifted = A + (self.alpha - tol) * self.In 
+            A_shifted = A + (self.alpha - tol) * self.In
             A_shifted_T = A_shifted.mT.contiguous()
 
             # Batched Kronecker product using vmap for cleaner implementation
             def _single_kron_sum(A_single):
                 I_single = torch.eye(self.n, device=A.device, dtype=A.dtype)
                 return torch.kron(I_single, A_single) + torch.kron(A_single, I_single)
-            
-            flat_batch_size = torch.prod(torch.tensor(self.tensorial_size)) if self.tensorial_size else 1
+
+            flat_batch_size = math.prod(self.tensorial_size)
             A_flat = A_shifted_T.reshape(flat_batch_size, self.n, self.n)
 
             M_flat = torch.vmap(_single_kron_sum)(A_flat)
-            M = M_flat.reshape(*self.tensorial_size, self.n*self.n, self.n*self.n)
+            M = M_flat.reshape(*self.tensorial_size, self.n * self.n, self.n * self.n)
 
-            Q = (rho * self.In)              
+            Q = (rho * self.In)
             flat_Q = Q.flatten(-2, -1)
-
 
             vec_P = torch.linalg.solve(M, -flat_Q.unsqueeze(-1)).squeeze(-1)
             P = vec_P.view(*self.tensorial_size, self.n, self.n)
 
             residual = torch.norm(A.mT @ P + P @ A + 2 * (self.alpha - tol) * P + Q)
-            if residual >=tol:
-                raise ValueError(f"Lyapunov equation ill-conditioned solve failed. \n Residual norm: {torch.norm(residual):.2e}")
+            if residual >= tol:
+                raise ValueError(
+                    f"Lyapunov equation ill-conditioned solve failed. \n Residual norm: {torch.norm(residual):.2e}")
 
-            S = P @ (A + (self.alpha-tol) * self.In) + 0.5 * Q 
+            S = P @ (A + (self.alpha - tol) * self.In) + 0.5 * Q
 
             P_inv = torch.inverse(P)
 
             return Q, P_inv, S
 
-        
     def right_inverse(self, A, check_in_manifold=True):
         Q, P, S = self.submersion_inv(A, check_in_manifold)
         X1, X2, X3 = super().right_inverse([Q, P, S])
         return X1, X2, X3
-    
+
     def in_manifold_eigen(self, A, eps=1e-6):
         r"""
         Check that all eigenvalues have real part lower than -alpha
@@ -130,7 +130,6 @@ class Hurwitz(ProductManifold):
         eig = torch.linalg.eigvals(A)
         reig = torch.real(eig)
         return (reig <= -self.alpha + eps).all().item()
-    
 
     def sample(self, init_=torch.nn.init.xavier_normal_):
         r"""
@@ -159,14 +158,13 @@ class Hurwitz(ProductManifold):
             P = mani_psd.sample(init_)
             Q = mani_psd.sample(init_)
             S = mani_skew.sample(init_)
-            
+
             A = self.submersion(Q, P, S)
             return A
-
 
     def extra_repr(self) -> str:
         print(self.alpha)
         return _extra_repr(
             n=self.n,
             alpha=self.alpha
-            )
+        )

--- a/geotorch/hurwitz.py
+++ b/geotorch/hurwitz.py
@@ -20,7 +20,7 @@ class Hurwitz(ProductManifold):
         Manifold of matrices with eigenvalues with negative real parts,
         also called Hurwitz matrices.
 
-        :math`A` is Hurwitz with prescribed decay rate \alpha
+        :math`A` is Hurwitz with prescribed decay rate :math:`\alpha`
         if and only if it can be written as
         ..math::
             A = P^{-1}(-\frac{Q}{2} +S) - \alpha \mathrm{I}_n

--- a/geotorch/hurwitz.py
+++ b/geotorch/hurwitz.py
@@ -1,0 +1,177 @@
+import torch
+from .psd import PSD
+from .skew import Skew
+from .product import ProductManifold
+from .exceptions import VectorError, NonSquareError
+from .utils import _extra_repr
+from .exceptions import (
+    VectorError,
+    NonSquareError,
+    InManifoldError,
+)
+
+def get_lyap_exp(A):
+    return -torch.max(torch.real(torch.linalg.eigvals(A)))
+
+class Hurwitz(ProductManifold):
+
+    def __init__(self, size, alpha: float = 0.0, triv="expm"):
+        r"""
+        Manifold of matrices with eigenvalues with negative real parts,
+        also called Hurwitz matrices. They represend linear stable linear dynamical systems.
+
+        We have the following result : A is Hurwitz with prescribed decay rate \alpha
+        if and only if it can be written as
+        :math:`A = P^{-1}(-\frac{Q}{2} +S) - \alpha I_n`
+        with $P > 0, Q > 0$ and ^S^skew-symmetric
+        Args:
+            size (torch.size): Size of the tensor to be parametrized
+            alpha (float): the upper bound on the matrix's eigenvalues real part
+                :math: `\min_{\lambda \in Sp(A)}  \Re(\lambda) \leq -\alpha`
+            triv (str or callable): Optional.
+                A map that maps skew-symmetric matrices onto the orthogonal matrices
+                surjectively. This is used to optimize the :math:`Q` in the eigenvalue
+                decomposition. It can be one of ``["expm", "cayley"]`` or a custom
+                callable. Default: ``"expm"``
+        """
+
+        assert alpha >=0, ValueError(f"alpha must be positive found {alpha}")
+
+        n, tensorial_size = Hurwitz.parse_size(size)
+        super().__init__(Hurwitz.manifolds(n, tensorial_size, triv))
+        self.n = n
+        self.tensorial_size = tensorial_size
+        self.alpha = alpha
+        self.register_buffer('In', torch.eye(n))
+
+    @classmethod
+    def parse_size(cls, size):
+        if len(size) < 2:
+            raise VectorError(cls.__name__, size)
+        n, k = size[-2:]
+        tensorial_size = size[:-2]
+        if n != k:
+            raise NonSquareError(cls.__name__, size)
+        return n, tensorial_size
+    
+    @staticmethod
+    def manifolds(n, tensorial_size, triv):
+        size = tensorial_size + (n, n)
+        return PSD(size, triv=triv), PSD(size, triv=triv), Skew(size)
+    
+
+    def submersion(self, Q, P, S):
+            return P @ (-0.5 * Q + S) - self.alpha * self.In
+
+    def forward(self, X1, X2, X3):
+        Q, P, S = super().forward([X1, X2, X3])
+        return self.submersion(Q, P, S)
+
+
+    def submersion_inv(self, A: torch.Tensor, check_in_manifold=True, rho=1, tol = 1e-5):
+        r"""
+            Args: 
+                A (torch.Tensor): a square and Hurwitz matrix with eigenvalues lower than -alpha
+                check_in_manifold (bool): if set to True we raise an error if the matrix A is not in
+                the manifold
+
+                rho (float): a scaling parameter for the matrix Q = -rho I
+
+        """
+        if check_in_manifold and not self.in_manifold_eigen(A):
+            print(f"Enforced alpha = {self.alpha} and given alpha = {get_lyap_exp(A)}")
+            raise InManifoldError(get_lyap_exp(A), self.alpha)
+        
+        with torch.no_grad():
+            A_shifted = A + (self.alpha - tol) * self.In 
+            A_shifted_T = A_shifted.mT.contiguous()
+            print(A_shifted.dtype)
+            M = torch.kron(self.In,  A_shifted_T) + torch.kron(A_shifted_T, self.In)
+            Q = (rho * self.In).unsqueeze(0).repeat(*self.tensorial_size, 1, 1)
+            flat_Q = Q.flatten(-2, -1)
+            vec_P = torch.linalg.solve(M, -flat_Q)
+            P = vec_P.view(*self.tensorial_size, self.n, self.n)
+            residual = A.mT @ P + P @ A + 2 * (self.alpha - tol)* P + Q
+            print(f"A eigenvalues : {torch.linalg.eigvals(A)}")
+            print(f"Alpha : {self.alpha}")
+            print(f"Residual norm: {torch.norm(residual):.2e}")
+
+            assert torch.allclose(A.mT @ P + P @ A + 2* (self.alpha - tol)*P, -Q, atol=1e-5)
+
+            S = P @ (A + (self.alpha-tol) * self.In) + 0.5 * Q 
+
+            print(S)
+            print(S.mT)
+            P_inv = torch.inverse(P)
+            A_rec = P_inv @ (-Q/2 + S) -(self.alpha-tol) * self.In
+            print(f"Distance between As at the end of computation of ri {torch.dist(A_rec, A)}")
+            print(f"Current alpha in submersion_inv {(self.alpha-tol)}")
+            return Q, P_inv, S
+
+        
+    def right_inverse(self, A, check_in_manifold=True):
+        Q, P, S = self.submersion_inv(A, check_in_manifold)
+        X1, X2, X3 = super().right_inverse([Q, P, S])
+        return X1, X2, X3
+    
+    def in_manifold_eigen(self, A, eps=1e-6):
+        r"""
+        Check that all eigenvalues have real part lower than -alpha
+        """
+        if A.size()[:-2] != self.tensorial_size:  # check dimensions
+            print(A.size(), self.tensorial_size)
+            return False
+        else:
+            eig = torch.linalg.eigvals(A)
+            reig = torch.real(eig)
+            return (reig <= -self.alpha + eps).all().item()
+        
+
+    def sample(self, init_=torch.nn.init.xavier_normal_, gamma=1.0):
+        r"""
+        Returns a randomly sampled Hurwitz (α-stable) matrix on the manifold as:
+
+            A = P^{-1}(-Q/2 + S) - αI,  with Q = γP
+
+        The output of this method can be used to initialize a parametrized tensor as::
+
+            >>> layer = nn.Linear(20, 20)
+            >>> M = Hurwitz(layer.weight.size(), alpha=0.5)
+            >>> geotorch.register_parametrization(layer, "weight", M)
+            >>> layer.weight = M.sample()
+
+        Args:
+            init_ (callable): Initialization method for random matrices.
+                            Default: ``torch.nn.init.xavier_normal_``
+            gamma (float): Scaling parameter for Q = gamma * P.
+                        Default: ``1.0``
+        """
+        with torch.no_grad():
+
+            X_p = torch.empty(*(self.tensorial_size + (self.n, self.n)))
+            init_(X_p)
+            P = X_p @ X_p.transpose(-2, -1) + 1e-3 * self.In  
+
+            X_q = torch.empty(*(self.tensorial_size + (self.n, self.n)))
+            init_(X_q)
+            Q = X_q @ X_q.mT + 1e-3 * self.In
+
+            
+            X_s = torch.empty_like(X_p)
+            init_(X_s)
+            S = X_s - X_s.transpose(-2, -1)
+
+            
+            P_inv = torch.inverse(P)
+            A = P_inv @ (-0.5 * Q + S) - self.alpha * self.In
+
+            return A
+
+
+    def extra_repr(self) -> str:
+        print(self.alpha)
+        return _extra_repr(
+            n=self.n,
+            alpha=self.alpha,
+            tensorial_size=self.tensorial_size,
+        )

--- a/geotorch/parametrize.py
+++ b/geotorch/parametrize.py
@@ -87,6 +87,7 @@ else:
                 Warning: the parametrization is not checked for consistency upon registration.
                 Enable this flag at your own risk.
         """
+
         original: Tensor
         unsafe: bool
 

--- a/geotorch/pssdfixedrank.py
+++ b/geotorch/pssdfixedrank.py
@@ -59,7 +59,6 @@ class PSSDFixedRank(SymF):
                 considered to be zero
                 Default: ``1e-6``
         """
-        print(L)
         return (
             super().in_manifold_eigen(L, eps)
             and (L[..., -self.rank :] >= eps).all().item()

--- a/geotorch/pssdfixedrank.py
+++ b/geotorch/pssdfixedrank.py
@@ -59,6 +59,7 @@ class PSSDFixedRank(SymF):
                 considered to be zero
                 Default: ``1e-6``
         """
+        print(L)
         return (
             super().in_manifold_eigen(L, eps)
             and (L[..., -self.rank :] >= eps).all().item()

--- a/geotorch/skew.py
+++ b/geotorch/skew.py
@@ -29,7 +29,7 @@ class Skew(nn.Module):
         if n != k:
             raise NonSquareError(cls.__name__, size)
         return n, tensorial_size
-    
+
     @staticmethod
     def frame(X, lower):
         if lower:
@@ -53,7 +53,7 @@ class Skew(nn.Module):
             return X.tril(-1)
         else:
             return X.triu(1)
-    
+
     @staticmethod
     def in_manifold(X):
         return (
@@ -61,7 +61,7 @@ class Skew(nn.Module):
             and X.size(-2) == X.size(-1)
             and torch.allclose(X, -X.transpose(-2, -1))
         )
-    
+
     def sample(self, init_=nn.init.xavier_normal_, lower=True):
         r"""
         Returns a randomly sampled matrix on the manifold as
@@ -90,8 +90,7 @@ class Skew(nn.Module):
                     Default: ``torch.nn.init.xavier_normal_``
         """
         with torch.no_grad():
-            X = torch.empty(
-                *(self.tensorial_size + (self.n, self.n)))
+            X = torch.empty(*(self.tensorial_size + (self.n, self.n)))
             init_(X)
             if lower:
                 X.tril_(-1)

--- a/geotorch/skew.py
+++ b/geotorch/skew.py
@@ -94,8 +94,7 @@ class Skew(nn.Module):
                 *(self.tensorial_size + (self.n, self.n)))
             init_(X)
             if lower:
-                tril_X = X.tril(-1)
-                return tril_X - tril_X.mT
+                X.tril_(-1)
             else:
-                triu_X = X.triu(1)
-                return triu_X - triu_X.mT
+                X.triu_(1)
+            return X - X.mT

--- a/geotorch/skew.py
+++ b/geotorch/skew.py
@@ -1,10 +1,10 @@
 import torch
 from torch import nn
-from .exceptions import VectorError, NonSquareError
+from .exceptions import VectorError, NonSquareError, InManifoldError
 
 
 class Skew(nn.Module):
-    def __init__(self, lower=True):
+    def __init__(self, size, lower=True):
         r"""
         Vector space of skew-symmetric matrices, parametrized in terms of
         the upper or lower triangular part of a matrix.
@@ -15,8 +15,21 @@ class Skew(nn.Module):
                 to parametrize the matrix. Default: ``True``
         """
         super().__init__()
+        n, tensorial_size = Skew.parse_size(size)
+        self.n = n
+        self.tensorial_size = tensorial_size
         self.lower = lower
 
+    @classmethod
+    def parse_size(cls, size):
+        if len(size) < 2:
+            raise VectorError(cls.__name__, size)
+        n, k = size[-2:]
+        tensorial_size = size[:-2]
+        if n != k:
+            raise NonSquareError(cls.__name__, size)
+        return n, tensorial_size
+    
     @staticmethod
     def frame(X, lower):
         if lower:
@@ -32,6 +45,15 @@ class Skew(nn.Module):
             raise NonSquareError(type(self).__name__, X.size())
         return self.frame(X, self.lower)
 
+    def right_inverse(self, X, check_in_manifold=True, tol=1e-4):
+        if check_in_manifold and not torch.allclose(X, -X.mT, atol=tol):
+            raise InManifoldError(X, self)
+        # We assume that X is skew_symmetric
+        if self.lower:
+            return X.tril(-1)
+        else:
+            return X.triu(1)
+    
     @staticmethod
     def in_manifold(X):
         return (
@@ -39,3 +61,41 @@ class Skew(nn.Module):
             and X.size(-2) == X.size(-1)
             and torch.allclose(X, -X.transpose(-2, -1))
         )
+    
+    def sample(self, init_=nn.init.xavier_normal_, lower=True):
+        r"""
+        Returns a randomly sampled matrix on the manifold as
+
+        .. math::
+
+            tril(W) \qquad W_{i,j} \sim \texttt{init_} if lower is set to True
+            tiu(W)  \qquad W_{i,j} \sim \texttt{init_} otherwise
+
+        By default ``init\_`` is a (xavier) normal distribution, so that the
+        returned matrix follows a Wishart distribution.
+
+        The output of this method can be used to initialize a parametrized tensor
+        that has been parametrized with this or any other manifold as::
+
+            >>> layer = nn.Linear(20, 20)
+            >>> M = Skew(layer.weight.size())
+            >>> geotorch.register_parametrization(layer, "weight", M)
+            >>> layer.weight = M.sample()
+
+        Args:
+            init\_ (callable): Optional.
+                    A function that takes a tensor and fills it in place according
+                    to some distribution. See
+                    `torch.init <https://pytorch.org/docs/stable/nn.init.html>`_.
+                    Default: ``torch.nn.init.xavier_normal_``
+        """
+        with torch.no_grad():
+            X = torch.empty(
+                *(self.tensorial_size + (self.n, self.n)))
+            init_(X)
+            if lower:
+                tril_X = X.tril(-1)
+                return tril_X - tril_X.mT
+            else:
+                triu_X = X.triu(1)
+                return triu_X - triu_X.mT

--- a/geotorch/utils.py
+++ b/geotorch/utils.py
@@ -49,6 +49,6 @@ def _extra_repr(**kwargs):  # noqa: C901
         if kwargs["transposed"]:
             ret += ", transposed"
     if "alpha" in kwargs:
-        ret += ", alpha={}".format(kwargs['alpha'])
+        ret += ", alpha={}".format(kwargs["alpha"])
 
     return ret

--- a/geotorch/utils.py
+++ b/geotorch/utils.py
@@ -48,4 +48,7 @@ def _extra_repr(**kwargs):  # noqa: C901
     if "transposed" in kwargs:
         if kwargs["transposed"]:
             ret += ", transposed"
+    if "alpha" in kwargs:
+        ret += ", alpha={}".format(kwargs['alpha'])
+
     return ret

--- a/test/test_hurwitz.py
+++ b/test/test_hurwitz.py
@@ -1,0 +1,97 @@
+import torch
+torch.set_default_dtype(torch.float64)
+from unittest import TestCase
+from geotorch.hurwitz import Hurwitz, get_lyap_exp
+from geotorch.exceptions import NonSquareError, VectorError, InManifoldError
+
+class TestHurwitz(TestCase):
+
+    def setUp(self):
+        self.size = (1, 5, 5)
+        self.alpha = 0.0
+        self.hurwitz = Hurwitz(self.size, alpha=self.alpha)
+
+    def test_parse_size_correct(self):
+        n, tensorial_size = self.hurwitz.parse_size(self.size)
+        self.assertEqual(n, 5)
+        self.assertEqual(tensorial_size, (1,))
+
+    def test_parse_size_non_square_error(self):
+        with self.assertRaises(NonSquareError):
+            self.hurwitz.parse_size((5, 3))
+
+    def test_parse_size_vector_error(self):
+        with self.assertRaises(VectorError):
+            self.hurwitz.parse_size((5,))
+
+    def test_sample_shape_and_hurwitz(self):
+        A = self.hurwitz.sample()
+        self.assertEqual(A.shape, self.size)
+        self.assertTrue(self.hurwitz.in_manifold_eigen(A))
+
+    def test_forward_and_submersion(self):
+        X1, X2, X3 = [torch.randn(5, 5) for _ in range(3)]
+        A = self.hurwitz.forward(X1, X2, X3)
+        self.assertEqual(A.shape, self.size)
+        self.assertTrue(torch.is_tensor(A))
+
+    def test_submersion_inv_valid_matrix(self):
+        A = self.hurwitz.sample()
+        alpha = get_lyap_exp(A) - 1e-4
+        self.hurwitz.alpha = alpha
+        Q, P_inv, S = self.hurwitz.submersion_inv(A)
+        self.assertEqual(Q.shape, self.size)
+        self.assertEqual(P_inv.shape, self.size)
+        self.assertEqual(S.shape, self.size)
+
+        A_reconstructed = P_inv @ (-0.5 * Q + S) - self.hurwitz.alpha * torch.eye(5)
+        self.assertTrue(torch.allclose(A, A_reconstructed, atol=1e-4))
+
+    def test_submersion_inv_in_manifold_error(self):
+        A_unstable = torch.eye(5)
+        with self.assertRaises(InManifoldError):
+            self.hurwitz.submersion_inv(A_unstable)
+
+    def test_right_inverse(self):
+        A = self.hurwitz.sample()
+        self.hurwitz.alpha = get_lyap_exp(A)
+        X1, X2, X3 = self.hurwitz.right_inverse(A)
+        A_from_ri = self.hurwitz.forward(X1, X2, X3)
+        self.assertTrue(torch.allclose(A, A_from_ri, atol=1e-4))
+
+    def test_in_manifold_eigen_true(self):
+        A = -torch.eye(5) * (self.alpha + 1)
+        self.assertTrue(self.hurwitz.in_manifold_eigen(A.unsqueeze(0)))
+
+    def test_in_manifold_eigen_false(self):
+        A = torch.eye(5)
+        self.assertFalse(self.hurwitz.in_manifold_eigen(A))
+
+    def test_initialization_alpha_negative(self):
+        with self.assertRaises(AssertionError):
+            Hurwitz(self.size, alpha=-0.1)
+
+    def test_extra_repr(self):
+        repr_str = self.hurwitz.extra_repr()
+        print(repr_str)
+        self.assertIn('n=5', repr_str)
+        self.assertIn('alpha=', repr_str)
+
+    def test_sample(self):
+        hurwitz = Hurwitz((5, 5), alpha=self.alpha)
+        A = hurwitz.sample()
+        self.assertEqual(A.shape, (5, 5))
+        self.assertTrue(hurwitz.in_manifold_eigen(A))
+
+    def test_batch_submersion_inv(self):
+        hurwitz_batch = Hurwitz((1, 2, 2))
+        A_batch = hurwitz_batch.sample()
+        print(A_batch)
+        print(f"Eigenvalues : {torch.linalg.eigvals(A_batch)}")
+        hurwitz_batch.alpha = get_lyap_exp(A_batch)
+        print(f"Alpha for the test : {hurwitz_batch.alpha}")
+        Q, P_inv, S = hurwitz_batch.submersion_inv(A_batch)
+        A_reconstructed = P_inv @ (-0.5 * Q + S) - (hurwitz_batch.alpha -1e-6) * torch.eye(2)
+        print(f"self.alpha {hurwitz_batch.alpha}")
+        print(f"Distance between As : {torch.dist(A_batch, A_reconstructed)}")
+        self.assertTrue(torch.allclose(A_batch, A_reconstructed, atol=1e-4))

--- a/test/test_hurwitz.py
+++ b/test/test_hurwitz.py
@@ -3,6 +3,7 @@ from geotorch.exceptions import NonSquareError, VectorError, InManifoldError
 from geotorch.hurwitz import Hurwitz, get_lyap_exp
 from unittest import TestCase
 import torch
+
 torch.set_default_dtype(torch.float64)
 
 
@@ -77,8 +78,8 @@ class TestHurwitz(TestCase):
 
     def test_extra_repr(self):
         repr_str = self.hurwitz.extra_repr()
-        self.assertIn('n=5', repr_str)
-        self.assertIn('alpha=', repr_str)
+        self.assertIn("n=5", repr_str)
+        self.assertIn("alpha=", repr_str)
 
     def test_sample(self):
         hurwitz = Hurwitz((5, 5), alpha=self.alpha)
@@ -97,13 +98,15 @@ class TestHurwitz(TestCase):
         A_batch = hurwitz_batch.sample()
         hurwitz_batch.alpha = float(get_lyap_exp(A_batch))
         Q, P_inv, S = hurwitz_batch.submersion_inv(A_batch)
-        A_reconstructed = P_inv @ (-0.5 * Q + S) - \
-            (hurwitz_batch.alpha - 1e-6) * torch.eye(2)
+        A_reconstructed = P_inv @ (-0.5 * Q + S) - (
+            hurwitz_batch.alpha - 1e-6
+        ) * torch.eye(2)
 
         self.assertTrue(torch.allclose(A_batch, A_reconstructed, atol=1e-4))
 
     def test_register_hurwitz(self):
         layer = torch.nn.Linear(self.size[-2], self.size[-1])
         geotorch.alpha_stable(layer, "weight", alpha=0.5)
-        self.assertTrue(torch.all(torch.real(
-            torch.linalg.eigvals(layer.weight)) <= -0.5))
+        self.assertTrue(
+            torch.all(torch.real(torch.linalg.eigvals(layer.weight)) <= -0.5)
+        )

--- a/test/test_hurwitz.py
+++ b/test/test_hurwitz.py
@@ -1,9 +1,10 @@
+import geotorch
+from geotorch.exceptions import NonSquareError, VectorError, InManifoldError
+from geotorch.hurwitz import Hurwitz, get_lyap_exp
+from unittest import TestCase
 import torch
 torch.set_default_dtype(torch.float64)
-from unittest import TestCase
-from geotorch.hurwitz import Hurwitz, get_lyap_exp
-from geotorch.exceptions import NonSquareError, VectorError, InManifoldError
-import geotorch
+
 
 class TestHurwitz(TestCase):
 
@@ -63,7 +64,7 @@ class TestHurwitz(TestCase):
 
     def test_in_manifold_eigen_true(self):
         A = -torch.eye(5) * (self.alpha + 1)
-        hurwitz = Hurwitz((1,5,5), alpha=self.alpha)
+        hurwitz = Hurwitz((1, 5, 5), alpha=self.alpha)
         self.assertTrue(hurwitz.in_manifold_eigen(A.unsqueeze(0)))
 
     def test_in_manifold_eigen_false(self):
@@ -96,11 +97,13 @@ class TestHurwitz(TestCase):
         A_batch = hurwitz_batch.sample()
         hurwitz_batch.alpha = float(get_lyap_exp(A_batch))
         Q, P_inv, S = hurwitz_batch.submersion_inv(A_batch)
-        A_reconstructed = P_inv @ (-0.5 * Q + S) - (hurwitz_batch.alpha -1e-6) * torch.eye(2)
+        A_reconstructed = P_inv @ (-0.5 * Q + S) - \
+            (hurwitz_batch.alpha - 1e-6) * torch.eye(2)
 
         self.assertTrue(torch.allclose(A_batch, A_reconstructed, atol=1e-4))
 
     def test_register_hurwitz(self):
         layer = torch.nn.Linear(self.size[-2], self.size[-1])
         geotorch.alpha_stable(layer, "weight", alpha=0.5)
-        self.assertTrue(torch.all(torch.real(torch.linalg.eigvals(layer.weight)) <= -0.5))
+        self.assertTrue(torch.all(torch.real(
+            torch.linalg.eigvals(layer.weight)) <= -0.5))

--- a/test/test_skew.py
+++ b/test/test_skew.py
@@ -9,6 +9,7 @@ import geotorch.parametrize as P
 from geotorch.skew import Skew
 import geotorch
 
+
 class TestSkew(TestCase):
     def test_backprop(self):
         r"""Test that we may instantiate the parametrizations and
@@ -38,11 +39,11 @@ class TestSkew(TestCase):
             Skew(torch.rand(3, 2).size())
 
         with self.assertRaises(ValueError):
-            Skew((torch.rand(1, 3).size())
-)
+            Skew((torch.rand(1, 3).size()))
+
         # Try to instantiate it in a vector rather than a matrix
         with self.assertRaises(ValueError):
             Skew(torch.rand(4).size())
 
     def test_repr(self):
-        print(Skew((5,5)))
+        print(Skew((5, 5)))

--- a/test/test_skew.py
+++ b/test/test_skew.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 
 import geotorch.parametrize as P
 from geotorch.skew import Skew
-
+import geotorch
 
 class TestSkew(TestCase):
     def test_backprop(self):
@@ -19,8 +19,7 @@ class TestSkew(TestCase):
 
         for n, lower in itertools.product(sizes, [True, False]):
             layer = nn.Linear(n, n)
-            P.register_parametrization(layer, "weight", Skew(lower=lower))
-
+            geotorch.skew(layer, "weight", lower)
             input_ = torch.rand(5, n)
             optim = torch.optim.SGD(layer.parameters(), lr=1.0)
 
@@ -36,14 +35,14 @@ class TestSkew(TestCase):
     def test_non_square(self):
         # Non-square skew
         with self.assertRaises(ValueError):
-            Skew()(torch.rand(3, 2))
+            Skew(torch.rand(3, 2).size())
 
         with self.assertRaises(ValueError):
-            Skew()(torch.rand(1, 3))
-
+            Skew((torch.rand(1, 3).size())
+)
         # Try to instantiate it in a vector rather than a matrix
         with self.assertRaises(ValueError):
-            Skew()(torch.rand(4))
+            Skew(torch.rand(4).size())
 
     def test_repr(self):
-        print(Skew())
+        print(Skew((5,5)))


### PR DESCRIPTION
I added a parameterizations of Hurwitz matrices, i.e. the one that have eigenvalues with negative real parts they represent stable linear dynamical systems. Optionally one can enforce a specific bound on the matrix decay rate named alpha, it is related to the concept of alpha-stability in Lyapunov linear theory.

In order to build this parameterization, I changed the constructor of the Skew class that now takes a size parameter. 
Now the parameterization is instantiated with _register_manifold instead of register_parameterization.
The test_skey.py file has been modified accordingly.

(This is my first PR ever do not hesitate to come back to me if something does not meet the requirements)