### PR TITLE
Reduce manifold sampling temporaries

### DIFF
--- a/geotorch/fixedrank.py
+++ b/geotorch/fixedrank.py
@@ -113,8 +113,8 @@ class FixedRank(LowRank):
         """
         U, S, V = super().sample(factorized=True, init_=init_)
         with torch.no_grad():
-            # S >= 0, as given by torch.linalg.eigvalsh()
-            S[S < eps] = eps
+            # S >= 0, as given by torch.linalg.svd()
+            S.clamp_min_(eps)
         if factorized:
             return U, S, V
         else:

--- a/geotorch/lowrank.py
+++ b/geotorch/lowrank.py
@@ -107,7 +107,7 @@ class LowRank(ProductManifold):
             return True
         # We compute the \infty-norm of the remaining dimension
         D = S[..., self.rank :]
-        infty_norm_err = D.abs().max(dim=-1).values
+        infty_norm_err = D.abs().amax(dim=-1)
         return (infty_norm_err < eps).all()
 
     def in_manifold(self, X, eps=1e-5):

--- a/geotorch/pssdfixedrank.py
+++ b/geotorch/pssdfixedrank.py
@@ -95,5 +95,5 @@ class PSSDFixedRank(SymF):
         L, Q = super().sample(factorized=True, init_=init_)
         with torch.no_grad():
             # L >= 0, as given by torch.linalg.eigvalsh()
-            L[L < eps] = eps
+            L.clamp_min_(eps)
         return (Q * L.unsqueeze(-2)) @ Q.transpose(-2, -1)

--- a/geotorch/sphere.py
+++ b/geotorch/sphere.py
@@ -16,14 +16,13 @@ def uniform_init_sphere_(x, r=1.0):
     """
     with torch.no_grad():
         x.normal_()
-        x.copy_(r * project(x))
+        x.copy_(project(x)).mul_(r)
     return x
 
 
 def _in_sphere(x, r, eps):
     norm = torch.linalg.vector_norm(x, dim=-1)
-    rs = torch.full_like(norm, r)
-    return (torch.linalg.vector_norm(norm - rs, ord=float("inf")) < eps).all()
+    return (norm - r).abs().amax() < eps
 
 
 class SphereEmbedded(nn.Module):

--- a/geotorch/symmetric.py
+++ b/geotorch/symmetric.py
@@ -168,7 +168,7 @@ class SymF(ProductManifold):
         if L.size(-1) > self.rank:
             # We compute the \infty-norm of the remaining dimension
             D = L[..., : -self.rank]
-            infty_norm_err = D.abs().max(dim=-1).values
+            infty_norm_err = D.abs().amax(dim=-1)
             if (infty_norm_err > 5.0 * eps).any():
                 return False
         return (L[..., -self.rank :] >= -eps).all().item()

--- a/test/test_lowrank.py
+++ b/test/test_lowrank.py
@@ -56,3 +56,12 @@ class TestLowRank(TestCase):
             with mock.patch("torch.linalg.svd", side_effect=AssertionError):
                 sample = manifold.sample(init_)
             self.assertTrue(torch.equal(sample, expected))
+
+    def test_fixed_rank_sample_clamps_singular_values(self):
+        manifold = FixedRank(size=(3, 3), rank=2).double()
+        _, singular_values, _ = manifold.sample(
+            init_=lambda X: X.zero_(), eps=0.25, factorized=True
+        )
+        self.assertTrue(
+            torch.equal(singular_values, torch.full_like(singular_values, 0.25))
+        )

--- a/test/test_positive_semidefinite.py
+++ b/test/test_positive_semidefinite.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+import torch
+
 from geotorch.pssdlowrank import PSSDLowRank
 from geotorch.pssdfixedrank import PSSDFixedRank
 from geotorch.pssd import PSSD
@@ -40,3 +42,10 @@ class TestPSSDLowRank(TestCase):
             PSD(size=(5, 2), f=3)
         with self.assertRaises(ValueError):
             PSD(size=(5, 3), f="fail")
+
+    def test_fixed_rank_sample_clamps_eigenvalues(self):
+        manifold = PSSDFixedRank(size=(3, 3), rank=2).double()
+        sample = manifold.sample(init_=lambda X: X.zero_(), eps=0.25)
+        eigenvalues = torch.linalg.eigvalsh(sample)
+        expected = torch.tensor([0.0, 0.25, 0.25], dtype=torch.float64)
+        torch.testing.assert_close(eigenvalues, expected)

--- a/test/test_sphere.py
+++ b/test/test_sphere.py
@@ -51,3 +51,11 @@ class TestSphere(TestCase):
         sample = sphere.sample()
         self.assertEqual(sample.dtype, torch.float64)
         self.assertEqual(sample.shape, (2, 3))
+
+    def test_membership_preserves_strict_epsilon_boundary(self):
+        sphere = SphereEmbedded(size=(1,), radius=2.0)
+        x = torch.tensor([2.0001], dtype=torch.float64)
+        eps = (torch.linalg.vector_norm(x) - sphere.radius).item()
+
+        self.assertFalse(sphere.in_manifold(x, eps=eps))
+        self.assertTrue(sphere.in_manifold(x, eps=2.0 * eps))


### PR DESCRIPTION
## Summary

- replace masked spectral writes with in-place `clamp_min_`
- use value-only `amax` reductions where indices are unused
- reduce temporary tensors in sphere sampling and membership checks
- preserve all existing epsilon values and comparison semantics

## Why

These equivalent expressions remove boolean masks, unused reduction outputs, and full-sized temporary tensors without changing manifold tolerance behavior.

## Validation

- `pytest -s --tb=short -n8 test/test_lowrank.py test/test_positive_semidefinite.py test/test_sphere.py test/test_integration.py`
- included in the full remote suite: `60 passed, 1 skipped`
