### PR TITLE
Normalize custom maps in SL parametrizations

### DIFF
--- a/geotorch/sl.py
+++ b/geotorch/sl.py
@@ -30,18 +30,15 @@ class SL(GLp):
         super().__init__(size, SL.parse_f(f), triv)
 
     @staticmethod
-    def parse_f(f_name):
-        if f_name in FixedRank.fs.keys():
-            f, inv = FixedRank.parse_f(f_name)
+    def parse_f(f):
+        f, inv = FixedRank.parse_f(f)
 
-            def f_sl(x):
-                y = f(x)
-                log_y = y.log()
-                return (log_y - log_y.mean(dim=-1, keepdim=True)).exp()
+        def f_sl(x):
+            y = f(x)
+            log_y = y.log()
+            return (log_y - log_y.mean(dim=-1, keepdim=True)).exp()
 
-            return (f_sl, inv)
-        else:
-            return f_name
+        return f_sl, inv
 
     def in_manifold_singular_values(self, S, eps=5e-3):
         rank_eps = torch.finfo(S.dtype).eps * max(self.n, self.k)

--- a/test/test_sl.py
+++ b/test/test_sl.py
@@ -26,6 +26,20 @@ class TestSL(TestCase):
             )
         )
 
+    def test_custom_map_is_normalized(self):
+        manifold = SL(size=(2, 3, 3), f=(torch.exp, torch.log)).double()
+        X = torch.randn(2, 3, 3, dtype=torch.float64)
+        matrix = manifold(X)
+        sign, logabsdet = torch.linalg.slogdet(matrix)
+
+        self.assertTrue(torch.equal(sign, torch.ones_like(sign)))
+        torch.testing.assert_close(
+            logabsdet, torch.zeros_like(logabsdet), atol=1e-6, rtol=0
+        )
+
+        inverse = manifold.right_inverse(matrix)
+        torch.testing.assert_close(manifold(inverse), matrix, atol=1e-6, rtol=1e-6)
+
     def test_negative_determinant_is_rejected(self):
         manifold = SL(size=(2, 2))
         self.assertFalse(manifold.in_manifold(torch.diag(torch.tensor([-1.0, 1.0]))))


### PR DESCRIPTION
## Summary

- normalize every accepted `SL` singular-value map in the log domain
- preserve inverse support for custom `(forward, inverse)` map pairs
- add coverage for custom maps and determinant-one round trips

## Why

Previously, only the built-in `"softplus"` map was normalized. Custom positive maps could therefore produce matrices outside `SL(n)` despite being accepted by the public API.

## Validation

- `pytest -s --tb=short -n8 test/test_sl.py`
- included in the full remote suite: `60 passed, 1 skipped`
